### PR TITLE
Fix slider element query and add guards

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
     <h2>Ближайшие события</h2>
   </div>
   <div class="slider-wrapper">
-    <div class="cards-carousel">
+    <div class="cards-carousel" id="sliderTrack">
       <div class="card">
         <div class="img-wrap">
           <img src="images/photo2.jpg" alt="Москва">

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -61,10 +61,11 @@ function visibleCount() {
 }
 
 function cardStepWidth() {
-  return cards[0].offsetWidth + 24;
+  return cards[0] ? cards[0].offsetWidth + 24 : 0;
 }
 
 function scrollToCardGroup(index) {
+  if (!track) return;
   const offset = cardStepWidth() * visibleCount() * index;
   track.scrollTo({ left: offset, behavior: 'smooth' });
 }
@@ -93,7 +94,7 @@ document.querySelector('.nav.prev')?.addEventListener('click', () => {
 });
 
 window.addEventListener('resize', () => {
-  scrollToCardGroup(currentIndex);
+  if (track) scrollToCardGroup(currentIndex);
 });
 
 


### PR DESCRIPTION
## Summary
- match HTML slider element with `id="sliderTrack"`
- safeguard slider JS methods when the element is missing

## Testing
- `true`